### PR TITLE
Extra-property checking for intersections

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,14 +5,13 @@
 
 import {IContext, NoopContext} from "./util";
 
-export type CheckerFunc = (value: any, ctx: IContext, allowedExtraneousProps?: Set<string>) => boolean;
+export type CheckerFunc = (value: any, ctx: IContext) => boolean;
+
+export type StrictFlag = boolean | {allowedProps: Set<string>};
 
 /** Node that represents a type. */
 export abstract class TType {
-  public abstract getChecker(suite: ITypeSuite, strict: boolean): CheckerFunc;
-  public getPropSet(suite: ITypeSuite): Set<string> {
-    return new Set()
-  }
+  public abstract getChecker(suite: ITypeSuite, strict: StrictFlag): CheckerFunc;
 }
 
 /**
@@ -48,19 +47,12 @@ export class TName extends TType {
   private _failMsg: string;
   constructor(public name: string) { super(); this._failMsg = `is not a ${name}`; }
 
-  public getPropSet(suite: ITypeSuite) {
-    const ttype = getNamedType(suite, this.name)
-    return ttype.getPropSet(suite)
-  }
-
-  public getChecker(suite: ITypeSuite, strict: boolean): CheckerFunc {
+  public getChecker(suite: ITypeSuite, strict: StrictFlag): CheckerFunc {
     const ttype = getNamedType(suite, this.name);
     const checker = ttype.getChecker(suite, strict);
     if (ttype instanceof BasicType || ttype instanceof TName) { return checker; }
     // For complex types, add an additional "is not a <Type>" message on failure.
-    return (value: any, ctx: IContext, allowedExtraneousProps?: Set<string>) => {
-      return checker(value, ctx, allowedExtraneousProps) ? true : ctx.fail(null, this._failMsg, 0);
-    }
+    return (value: any, ctx: IContext) => checker(value, ctx) ? true : ctx.fail(null, this._failMsg, 0);
   }
 }
 
@@ -77,7 +69,7 @@ export class TLiteral extends TType {
     this._failMsg = `is not ${this.name}`;
   }
 
-  public getChecker(suite: ITypeSuite, strict: boolean): CheckerFunc {
+  public getChecker(suite: ITypeSuite, strict: StrictFlag): CheckerFunc {
     return (value: any, ctx: IContext) => (value === this.value) ? true : ctx.fail(null, this._failMsg, -1);
   }
 }
@@ -89,7 +81,7 @@ export function array(typeSpec: TypeSpec): TArray { return new TArray(parseSpec(
 export class TArray extends TType {
   constructor(public ttype: TType) { super(); }
 
-  public getChecker(suite: ITypeSuite, strict: boolean): CheckerFunc {
+  public getChecker(suite: ITypeSuite, strict: StrictFlag): CheckerFunc {
     const itemChecker = this.ttype.getChecker(suite, strict);
     return (value: any, ctx: IContext) => {
       if (!Array.isArray(value)) { return ctx.fail(null, "is not an array", 0); }
@@ -111,7 +103,7 @@ export function tuple(...typeSpec: TypeSpec[]): TTuple {
 export class TTuple extends TType {
   constructor(public ttypes: TType[]) { super(); }
 
-  public getChecker(suite: ITypeSuite, strict: boolean): CheckerFunc {
+  public getChecker(suite: ITypeSuite, strict: StrictFlag): CheckerFunc {
     const itemCheckers = this.ttypes.map((t) => t.getChecker(suite, strict));
     const checker = (value: any, ctx: IContext) => {
       if (!Array.isArray(value)) { return ctx.fail(null, "is not an array", 0); }
@@ -155,7 +147,7 @@ export class TUnion extends TType {
     }
   }
 
-  public getChecker(suite: ITypeSuite, strict: boolean): CheckerFunc {
+  public getChecker(suite: ITypeSuite, strict: StrictFlag): CheckerFunc {
     const itemCheckers = this.ttypes.map((t) => t.getChecker(suite, strict));
     return (value: any, ctx: IContext) => {
       const ur = ctx.unionResolver();
@@ -180,16 +172,14 @@ export class TIntersection extends TType {
     super();
   }
 
-  public getChecker(suite: ITypeSuite, strict: boolean): CheckerFunc {
-    const itemCheckers = this.ttypes.map((t) => t.getChecker(suite, strict));
-    const propSets = this.ttypes.map((t) => t.getPropSet(suite))
-    const allProps = propSets.reduce(
-        (a, s) => new Set(Array.from(a).concat(Array.from(s))));
+  public getChecker(suite: ITypeSuite, strict: StrictFlag): CheckerFunc {
+    const extraProps = strict && {allowedProps: new Set()};
+    const itemCheckers = this.ttypes.map((t) => t.getChecker(suite, extraProps));
     return (value: any, ctx: IContext) => {
-      const ok = itemCheckers.every(checker => checker(value, ctx, allProps))
+      const ok = itemCheckers.every(checker => checker(value, ctx))
       if (ok) { return true; }
       return ctx.fail(null, null, 0);
-    }
+    };
   }
 }
 
@@ -207,7 +197,7 @@ export class TEnumType extends TType {
     super();
     this.validValues = new Set(Object.keys(members).map((name) => members[name]));
   }
-  public getChecker(suite: ITypeSuite, strict: boolean): CheckerFunc {
+  public getChecker(suite: ITypeSuite, strict: StrictFlag): CheckerFunc {
     return (value: any, ctx: IContext) =>
       (this.validValues.has(value) ? true : ctx.fail(null, this._failMsg, 0));
   }
@@ -225,7 +215,7 @@ export class TEnumLiteral extends TType {
     super();
     this._failMsg = `is not ${enumName}.${prop}`;
   }
-  public getChecker(suite: ITypeSuite, strict: boolean): CheckerFunc {
+  public getChecker(suite: ITypeSuite, strict: StrictFlag): CheckerFunc {
     const ttype = getNamedType(suite, this.enumName);
     if (!(ttype instanceof TEnumType)) {
       throw new Error(`Type ${this.enumName} used in enumlit is not an enum type`);
@@ -262,11 +252,7 @@ export class TIface extends TType {
     this.propSet = new Set(props.map((p) => p.name));
   }
 
-  public getPropSet(suite: ITypeSuite) {
-    return this.propSet;
-  }
-
-  public getChecker(suite: ITypeSuite, strict: boolean): CheckerFunc {
+  public getChecker(suite: ITypeSuite, strict: StrictFlag): CheckerFunc {
     const baseCheckers = this.bases.map((b) => getNamedType(suite, b).getChecker(suite, strict));
     const propCheckers = this.props.map((prop) => prop.ttype.getChecker(suite, strict));
     const testCtx = new NoopContext();
@@ -295,11 +281,17 @@ export class TIface extends TType {
 
     if (!strict) { return checker; }
 
+    let allowedProps = this.propSet;
+    if (typeof strict === 'object' && 'allowedProps' in strict) {
+      allowedProps = strict.allowedProps;
+      this.propSet.forEach((prop) => allowedProps.add(prop));
+    }
+
     // In strict mode, check also for unknown enumerable properties.
-    return (value: any, ctx: IContext, allowedExtraneousProps = new Set()) => {
+    return (value: any, ctx: IContext) => {
       if (!checker(value, ctx)) { return false; }
       for (const prop in value) {
-        if (!this.propSet.has(prop) && !allowedExtraneousProps.has(prop)) {
+        if (!allowedProps.has(prop)) {
           return ctx.fail(prop, "is extraneous", 2);
         }
       }
@@ -317,7 +309,7 @@ export class TOptional extends TType {
     super();
   }
 
-  public getChecker(suite: ITypeSuite, strict: boolean): CheckerFunc {
+  public getChecker(suite: ITypeSuite, strict: StrictFlag): CheckerFunc {
     const itemChecker = this.ttype.getChecker(suite, strict);
     return (value: any, ctx: IContext) => {
       return value === undefined || itemChecker(value, ctx);
@@ -342,7 +334,7 @@ export function func(resultSpec: TypeSpec, ...params: TParam[]): TFunc {
 export class TFunc extends TType {
   constructor(public paramList: TParamList, public result: TType) { super(); }
 
-  public getChecker(suite: ITypeSuite, strict: boolean): CheckerFunc {
+  public getChecker(suite: ITypeSuite, strict: StrictFlag): CheckerFunc {
     return (value: any, ctx: IContext) => {
       return typeof value === "function" ? true : ctx.fail(null, "is not a function", 0);
     };
@@ -365,7 +357,7 @@ export class TParam {
 export class TParamList extends TType {
   constructor(public params: TParam[]) { super(); }
 
-  public getChecker(suite: ITypeSuite, strict: boolean): CheckerFunc {
+  public getChecker(suite: ITypeSuite, strict: StrictFlag): CheckerFunc {
     const itemCheckers = this.params.map((t) => t.ttype.getChecker(suite, strict));
     const testCtx = new NoopContext();
     const isParamRequired: boolean[] = this.params.map((param, i) =>
@@ -401,7 +393,7 @@ export class TParamList extends TType {
 export class BasicType extends TType {
   constructor(public validator: (value: any) => boolean, private message: string) { super(); }
 
-  public getChecker(suite: ITypeSuite, strict: boolean): CheckerFunc {
+  public getChecker(suite: ITypeSuite, strict: StrictFlag): CheckerFunc {
     return (value: any, ctx: IContext) => this.validator(value) ? true : ctx.fail(null, this.message, 0);
   }
 }

--- a/test/fixtures/intersection-ti.ts
+++ b/test/fixtures/intersection-ti.ts
@@ -13,7 +13,7 @@ export const Car = t.intersection("Wheels", "Doors");
 
 export const House = t.intersection("Doors", t.iface([], {
   "numRooms": "number",
-}));
+}), "object");
 
 export const MixedLiteral = t.intersection(t.union(t.lit(1), t.lit(2)), t.union(t.lit(2), t.lit(3)));
 
@@ -32,6 +32,8 @@ export const SameKeyTypeB = t.iface([], {
 
 export const SameKeyIntersection = t.intersection("SameKeyTypeA", "SameKeyTypeB");
 
+export const Tuples = t.intersection(t.tuple("string", t.union("string", "null")), t.array("string"));
+
 const exportedTypeSuite: t.ITypeSuite = {
   Wheels,
   Doors,
@@ -41,5 +43,6 @@ const exportedTypeSuite: t.ITypeSuite = {
   SameKeyTypeA,
   SameKeyTypeB,
   SameKeyIntersection,
+  Tuples,
 };
 export default exportedTypeSuite;

--- a/test/fixtures/intersection.ts
+++ b/test/fixtures/intersection.ts
@@ -1,16 +1,14 @@
-interface Wheels {
+export interface Wheels {
   numWheels: number
 }
 
-interface Doors {
+export interface Doors {
   numDoors: number
 }
 
 export type Car = Wheels & Doors
 
-export type House = Doors & {
-  numRooms: number
-}
+export type House = Doors & {numRooms: number} & object;
 
 export type MixedLiteral = ( 1 | 2 ) & ( 2 | 3 )
 
@@ -28,3 +26,5 @@ export type SameKeyTypeB = {
 }
 
 export type SameKeyIntersection = SameKeyTypeA & SameKeyTypeB
+
+export type Tuples = [string, string|null] & string[];


### PR DESCRIPTION
Try a somewhat simpler implementation (remove extra method, move argument to `getChecker` func), and add some more test cases.